### PR TITLE
Add additional buttons to skip forward/back a fixed amount

### DIFF
--- a/mordenx.lua
+++ b/mordenx.lua
@@ -36,6 +36,9 @@ local user_opts = {
     seekrange = true,		-- show seekrange overlay
     seekrangealpha = 64,      	-- transparency of seekranges
     seekbarkeyframes = true,    -- use keyframes when dragging the seekbar
+    showjump = true,            -- show "jump forward/backward 5 seconds" buttons 
+                                -- shift+left-click to step 1 frame and 
+                                -- right-click to jump 1 minute
     title = '${media-title}',   -- string compatible with property-expansion
                                 -- to be shown as OSC title
     showtitle = true,		-- show title in OSC
@@ -1072,37 +1075,42 @@ layouts = function ()
     lo.slider.gap = 7
     lo.slider.tooltip_style = osc_styles.Tooltip
     lo.slider.tooltip_an = 2
+
+    local showjump = user_opts.showjump
+    local offset = showjump and 60 or 0
     
 	-- buttons
     lo = add_layout('pl_prev')
-    lo.geometry = {x = refX - 180, y = refY - 40 , an = 5, w = 30, h = 24}
+    lo.geometry = {x = refX - 120 - offset, y = refY - 40 , an = 5, w = 30, h = 24}
     lo.style = osc_styles.Ctrl2
 
 	lo = add_layout('skipback')
-    lo.geometry = {x = refX - 120, y = refY - 40 , an = 5, w = 30, h = 24}
-    lo.style = osc_styles.Ctrl2
-
-    lo = add_layout('jumpback')
-    lo.geometry = {x = refX - 60, y = refY - 40 , an = 5, w = 30, h = 24}
+    lo.geometry = {x = refX - 60 - offset, y = refY - 40 , an = 5, w = 30, h = 24}
     lo.style = osc_styles.Ctrl2
 
 
+    if showjump then
+        lo = add_layout('jumpback')
+        lo.geometry = {x = refX - 60, y = refY - 40 , an = 5, w = 30, h = 24}
+        lo.style = osc_styles.Ctrl2
+    end
 			
     lo = add_layout('playpause')
     lo.geometry = {x = refX, y = refY - 40 , an = 5, w = 45, h = 45}
     lo.style = osc_styles.Ctrl1	
 
-
-    lo = add_layout('jumpfrwd')
-    lo.geometry = {x = refX + 60, y = refY - 40 , an = 5, w = 30, h = 24}
-    lo.style = osc_styles.Ctrl2	
+    if showjump then
+        lo = add_layout('jumpfrwd')
+        lo.geometry = {x = refX + 60, y = refY - 40 , an = 5, w = 30, h = 24}
+        lo.style = osc_styles.Ctrl2	
+    end
 
     lo = add_layout('skipfrwd')
-    lo.geometry = {x = refX + 120, y = refY - 40 , an = 5, w = 30, h = 24}
+    lo.geometry = {x = refX + 60 + offset, y = refY - 40 , an = 5, w = 30, h = 24}
     lo.style = osc_styles.Ctrl2	
 
     lo = add_layout('pl_next')
-    lo.geometry = {x = refX + 180, y = refY - 40 , an = 5, w = 30, h = 24}
+    lo.geometry = {x = refX + 120 + offset, y = refY - 40 , an = 5, w = 30, h = 24}
     lo.style = osc_styles.Ctrl2
 
 
@@ -1243,34 +1251,36 @@ function osc_init()
     --ne.eventresponder['mbtn_right_up'] =
     --    function () mp.commandv('script-binding', 'open-file-dialog') end
 
-    --jumpback
-    ne = new_element('jumpback', 'button')
+    if user_opts.showjump then
+        --jumpback
+        ne = new_element('jumpback', 'button')
 
-    ne.softrepeat = true
-    ne.content = '\xEF\x8E\xB1'
-    ne.eventresponder['mbtn_left_down'] =
-        --function () mp.command('seek -5') end
-        function () mp.commandv('seek', -5, 'relative', 'keyframes') end
-    ne.eventresponder['shift+mbtn_left_down'] =
-        function () mp.commandv('frame-back-step') end
-    ne.eventresponder['mbtn_right_down'] =
-        --function () mp.command('seek -60') end
-        function () mp.commandv('seek', -60, 'relative', 'keyframes') end
+        ne.softrepeat = true
+        ne.content = '\xEF\x8E\xB1'
+        ne.eventresponder['mbtn_left_down'] =
+            --function () mp.command('seek -5') end
+            function () mp.commandv('seek', -5, 'relative', 'keyframes') end
+        ne.eventresponder['shift+mbtn_left_down'] =
+            function () mp.commandv('frame-back-step') end
+        ne.eventresponder['mbtn_right_down'] =
+            --function () mp.command('seek -60') end
+            function () mp.commandv('seek', -60, 'relative', 'keyframes') end
 
 
-    --jumpfrwd
-    ne = new_element('jumpfrwd', 'button')
+        --jumpfrwd
+        ne = new_element('jumpfrwd', 'button')
 
-    ne.softrepeat = true
-    ne.content = '\xEF\x8E\xA3'
-    ne.eventresponder['mbtn_left_down'] =
-        --function () mp.command('seek +5') end
-        function () mp.commandv('seek', 5, 'relative', 'keyframes') end
-    ne.eventresponder['shift+mbtn_left_down'] =
-        function () mp.commandv('frame-step') end
-    ne.eventresponder['mbtn_right_down'] =
-        --function () mp.command('seek +60') end
-        function () mp.commandv('seek', 60, 'relative', 'keyframes') end
+        ne.softrepeat = true
+        ne.content = '\xEF\x8E\xA3'
+        ne.eventresponder['mbtn_left_down'] =
+            --function () mp.command('seek +5') end
+            function () mp.commandv('seek', 5, 'relative', 'keyframes') end
+        ne.eventresponder['shift+mbtn_left_down'] =
+            function () mp.commandv('frame-step') end
+        ne.eventresponder['mbtn_right_down'] =
+            --function () mp.command('seek +60') end
+            function () mp.commandv('seek', 60, 'relative', 'keyframes') end
+    end
     
 
     --skipback

--- a/mordenx.lua
+++ b/mordenx.lua
@@ -1075,24 +1075,34 @@ layouts = function ()
     
 	-- buttons
     lo = add_layout('pl_prev')
-    lo.geometry = {x = refX - 120, y = refY - 40 , an = 5, w = 30, h = 24}
+    lo.geometry = {x = refX - 180, y = refY - 40 , an = 5, w = 30, h = 24}
     lo.style = osc_styles.Ctrl2
 
 	lo = add_layout('skipback')
+    lo.geometry = {x = refX - 120, y = refY - 40 , an = 5, w = 30, h = 24}
+    lo.style = osc_styles.Ctrl2
+
+    lo = add_layout('jumpback')
     lo.geometry = {x = refX - 60, y = refY - 40 , an = 5, w = 30, h = 24}
     lo.style = osc_styles.Ctrl2
+
 
 			
     lo = add_layout('playpause')
     lo.geometry = {x = refX, y = refY - 40 , an = 5, w = 45, h = 45}
     lo.style = osc_styles.Ctrl1	
 
-    lo = add_layout('skipfrwd')
+
+    lo = add_layout('jumpfrwd')
     lo.geometry = {x = refX + 60, y = refY - 40 , an = 5, w = 30, h = 24}
     lo.style = osc_styles.Ctrl2	
 
-    lo = add_layout('pl_next')
+    lo = add_layout('skipfrwd')
     lo.geometry = {x = refX + 120, y = refY - 40 , an = 5, w = 30, h = 24}
+    lo.style = osc_styles.Ctrl2	
+
+    lo = add_layout('pl_next')
+    lo.geometry = {x = refX + 180, y = refY - 40 , an = 5, w = 30, h = 24}
     lo.style = osc_styles.Ctrl2
 
 
@@ -1232,6 +1242,36 @@ function osc_init()
         function () mp.commandv('cycle', 'pause') end
     --ne.eventresponder['mbtn_right_up'] =
     --    function () mp.commandv('script-binding', 'open-file-dialog') end
+
+    --jumpback
+    ne = new_element('jumpback', 'button')
+
+    ne.softrepeat = true
+    ne.content = '\xEF\x8E\xB1'
+    ne.eventresponder['mbtn_left_down'] =
+        --function () mp.command('seek -5') end
+        function () mp.commandv('seek', -5, 'relative', 'keyframes') end
+    ne.eventresponder['shift+mbtn_left_down'] =
+        function () mp.commandv('frame-back-step') end
+    ne.eventresponder['mbtn_right_down'] =
+        --function () mp.command('seek -60') end
+        function () mp.commandv('seek', -60, 'relative', 'keyframes') end
+
+
+    --jumpfrwd
+    ne = new_element('jumpfrwd', 'button')
+
+    ne.softrepeat = true
+    ne.content = '\xEF\x8E\xA3'
+    ne.eventresponder['mbtn_left_down'] =
+        --function () mp.command('seek +5') end
+        function () mp.commandv('seek', 5, 'relative', 'keyframes') end
+    ne.eventresponder['shift+mbtn_left_down'] =
+        function () mp.commandv('frame-step') end
+    ne.eventresponder['mbtn_right_down'] =
+        --function () mp.command('seek +60') end
+        function () mp.commandv('seek', 60, 'relative', 'keyframes') end
+    
 
     --skipback
     ne = new_element('skipback', 'button')

--- a/mordenx.lua
+++ b/mordenx.lua
@@ -39,8 +39,8 @@ local user_opts = {
     showjump = true,            -- show "jump forward/backward 5 seconds" buttons 
                                 -- shift+left-click to step 1 frame and 
                                 -- right-click to jump 1 minute
-    jumpamount = 5,             -- change the jump amount in seconds. icon can
-                                -- show 5, 10, 30, but any number is valid
+    jumpamount = 5,             -- change the jump amount (in seconds by default)
+    jumpiconnumber = true,      -- show different icon when jumpamount is 5, 10, or 30
     jumpmode = 'exact',         -- seek mode for jump buttons. e.g.
                                 -- 'exact', 'relative+keyframes', etc.
     title = '${media-title}',   -- string compatible with property-expansion
@@ -1118,7 +1118,7 @@ layouts = function ()
 
         -- HACK: jumpfrwd's icon must be mirrored for nonstandard # of seconds
         -- as the font only has an icon without a number for rewinding
-        lo.style = (jumpicons[user_opts.jumpamount] ~= nil) and osc_styles.Ctrl2 or osc_styles.Ctrl2Flip
+        lo.style = (user_opts.jumpiconnumber and jumpicons[user_opts.jumpamount] ~= nil) and osc_styles.Ctrl2 or osc_styles.Ctrl2Flip
     end
 
     lo = add_layout('skipfrwd')
@@ -1270,7 +1270,10 @@ function osc_init()
     if user_opts.showjump then
         local jumpamount = user_opts.jumpamount
         local jumpmode = user_opts.jumpmode
-        local icons = jumpicons[jumpamount] or jumpicons.default
+        local icons = jumpicons.default
+        if user_opts.jumpiconnumber then
+            icons = jumpicons[jumpamount] or jumpicons.default
+        end
 
         --jumpback
         ne = new_element('jumpback', 'button')

--- a/mordenx.lua
+++ b/mordenx.lua
@@ -2066,17 +2066,21 @@ do_enable_keybindings()
 
 --mouse input bindings
 mp.set_key_bindings({
-    {'mbtn_left',           function(e) process_event('mbtn_left', 'up') end,
-                            function(e) process_event('mbtn_left', 'down')  end},
-    {'mbtn_right',          function(e) process_event('mbtn_right', 'up') end,
-                            function(e) process_event('mbtn_right', 'down')  end},
-    {'mbtn_mid',            function(e) process_event('mbtn_mid', 'up') end,
-                            function(e) process_event('mbtn_mid', 'down')  end},
-    {'wheel_up',            function(e) process_event('wheel_up', 'press') end},
-    {'wheel_down',          function(e) process_event('wheel_down', 'press') end},
-    {'mbtn_left_dbl',       'ignore'},
-    {'mbtn_right_dbl',      'ignore'},
-}, 'input', 'force')
+    {"mbtn_left",           function(e) process_event("mbtn_left", "up") end,
+                            function(e) process_event("mbtn_left", "down")  end},
+    {"shift+mbtn_left",     function(e) process_event("shift+mbtn_left", "up") end,
+                            function(e) process_event("shift+mbtn_left", "down")  end},
+    {"mbtn_right",          function(e) process_event("mbtn_right", "up") end,
+                            function(e) process_event("mbtn_right", "down")  end},
+    -- alias to shift_mbtn_left for single-handed mouse use
+    {"mbtn_mid",            function(e) process_event("shift+mbtn_left", "up") end,
+                            function(e) process_event("shift+mbtn_left", "down")  end},
+    {"wheel_up",            function(e) process_event("wheel_up", "press") end},
+    {"wheel_down",          function(e) process_event("wheel_down", "press") end},
+    {"mbtn_left_dbl",       "ignore"},
+    {"shift+mbtn_left_dbl", "ignore"},
+    {"mbtn_right_dbl",      "ignore"},
+}, "input", "force")
 mp.enable_key_bindings('input')
 
 mp.set_key_bindings({


### PR DESCRIPTION
This is what the chapter skip buttons used to do in the original modern. These buttons are added in addition to the chapter skip buttons so you can still skip around in a file with no chapters.

Preview:
<img width="960" alt="preview" src="https://user-images.githubusercontent.com/3376691/153718926-fa096704-2360-4259-95da-be3911b1f35b.png">
 
Left Mouse Button skips 5 seconds
Shift+LMB can skip 1 frame
RMB can skip 1 minute

These could be made optional with a config setting.